### PR TITLE
build: integrate swagger commands into development routine

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -5,7 +5,7 @@ tmp_dir = "./bin"
 [build]
   args_bin = []
   bin = "./bin/main"
-  cmd = "go run scripts/generate/main.go && go build -o ./bin/main ."
+  cmd = "go run scripts/generate/main.go && swag init && go build -o ./bin/main ."
   delay = 1000
   exclude_dir = [
     "assets",

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,17 @@ all: serve
 serve:
 	air
 
-sch: schema
-schema:
-	go run scripts/schema/main.go $(filter-out $@,$(MAKECMDGOALS))
-
 ti: test-integration
 test-integration:
 	go test -v $$(go list ./... | grep -v 'ent/\|docs/') -tags=integration
+
+swag: swagger
+swagger:
+	swag init
+
+sch: schema
+schema:
+	go run scripts/schema/main.go $(filter-out $@,$(MAKECMDGOALS))
 
 gen: generate
 generate:

--- a/README.md
+++ b/README.md
@@ -17,13 +17,21 @@ sudo pacman -S go
 - Windows  
   https://go.dev/doc/install
 
-## Install [`Air`](https://github.com/air-verse/air)
+## Install [`Air`](https://github.com/air-verse/air) (recommended)
 
 Air is a tool that provides a live reload server for Go applications, updating
 the running server when the source code changes, similar to `nodemon` for Node.js.
 
 ```command
 go install github.com/air-verse/air@latest
+```
+
+## Install [`Swag`](https://github.com/swaggo/swag)
+
+Swag is a tool that generates API documentation from Go source code.
+
+```command
+go install github.com/swaggo/swag/cmd/swag@latest
 ```
 
 ## Setup [`Husky`](https://github.com/automation-co/husky)


### PR DESCRIPTION
- Automatically run the swagger generation command when running the server with `air`;
- Add a `Makefile` alias for swagger generation command;