### PR TITLE
fix: `test` call syntax in `pre-commit` hook of `api`

### DIFF
--- a/.husky/hooks/commit-msg
+++ b/.husky/hooks/commit-msg
@@ -1,6 +1,12 @@
 #!/bin/sh
 
+# Semantic commit regex
 commit_regex="^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .{10,200}$"
+
+# Merge commit regex
+merge_commit_regex="^Merge (branch|remote-tracking branch) '.+' into .+$"
+
+# Error message for non-compliant commits
 error_msg="
 Commit message does not follow semantic guidelines!
 
@@ -13,7 +19,8 @@ Commit message does not follow semantic guidelines!
 Please fix your commit message and try again.
 "
 
-if ! grep -qE "$commit_regex" "$1"; then
+# Validate commit message
+if ! grep -qE "$commit_regex" "$1" && ! grep -qE "$merge_commit_regex" "$1"; then
     echo "$error_msg"
     exit 1
 fi

--- a/.husky/hooks/pre-commit
+++ b/.husky/hooks/pre-commit
@@ -10,7 +10,8 @@ go vet ./...
 
 # Run tests to ensure everything is working
 echo "Running tests..."
-go test -v "$(go list ./... | grep -v 'ent/\|docs/')"
+# shellcheck disable=2046
+go test -v $(go list ./... | grep -v 'ent/\|docs/\|_integration_test.go')
 
 # shellcheck disable=2181
 if [ $? -ne 0 ]; then

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ all: serve
 serve:
 	air
 
+t: test
+test:
+	go test -v $$(go list ./... | grep -v 'ent/\|docs/\|_integration_test.go')
+
 ti: test-integration
 test-integration:
 	go test -v $$(go list ./... | grep -v 'ent/\|docs/') -tags=integration

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,7 @@ database-up:
 db-down: database-down
 database-down:
 	docker-compose down
+
+h: hooks
+hooks:
+	husky install


### PR DESCRIPTION
- remove surrounding `"` from output of `go list`;
- prevents `malformed import path "[...]": invalid char '\n'` error