### PR TITLE
Seeds no confirm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ seeds:
 	go run scripts/seeds/main.go $(filter-out $@,$(MAKECMDGOALS))
 	@:
 
+sy: seeds-y
+seeds-y:
+	go run scripts/seeds/main.go $(filter-out $@,$(MAKECMDGOALS)) -y
+	@:
+
 db-up: database-up
 database-up:
 	docker-compose up -d

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,9 @@ swag: swagger
 swagger:
 	swag init
 
-sch: schema
+sch:
+	go run scripts/schema/main.go $(filter-out $@,$(MAKECMDGOALS))
+	@:
 schema:
 	go run scripts/schema/main.go $(filter-out $@,$(MAKECMDGOALS))
 	@:
@@ -48,7 +50,9 @@ seeds:
 	go run scripts/seeds/main.go $(filter-out $@,$(MAKECMDGOALS))
 	@:
 
-sy: seeds-y
+sy:
+	go run scripts/seeds/main.go $(filter-out $@,$(MAKECMDGOALS)) -y
+	@:
 seeds-y:
 	go run scripts/seeds/main.go $(filter-out $@,$(MAKECMDGOALS)) -y
 	@:

--- a/main.go
+++ b/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"api5back/src/database"
-	"api5back/src/server"
 	"fmt"
 	"net/http"
+
+	"api5back/src/database"
+	"api5back/src/server"
 )
 
 func main() {
@@ -25,6 +26,8 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Content-Type", "*/*")
 		if r.Method == "OPTIONS" {
 			return
 		}

--- a/scripts/seeds/main.go
+++ b/scripts/seeds/main.go
@@ -88,19 +88,26 @@ func main() {
 		panic(sb.String())
 	}
 
-	// ask for confirmation
-	fmt.Printf(
-		"scripts/seeds • Running seed `%s`, confirm? (y/N): ",
-		targetSeedsPreset.Name,
-	)
-
-	confirm, err := askForConfirmation()
-	if err != nil {
-		panic(fmt.Errorf("scripts/seeds • failed to ask for confirmation: %v", err))
+	confirm := true
+	if len(os.Args) > 2 && os.Args[2] == "-y" {
+		confirm = false
 	}
 
-	if !confirm {
-		return
+	if confirm {
+		// ask for confirmation
+		fmt.Printf(
+			"scripts/seeds • Running seed `%s`, confirm? (y/N): ",
+			targetSeedsPreset.Name,
+		)
+
+		confirm, err := askForConfirmation()
+		if err != nil {
+			panic(fmt.Errorf("scripts/seeds • failed to ask for confirmation: %v", err))
+		}
+
+		if !confirm {
+			return
+		}
 	}
 
 	seeds.Execute("DW", targetSeedsPreset.SeedsFunc)

--- a/src/model/factHiringProcess.go
+++ b/src/model/factHiringProcess.go
@@ -1,0 +1,20 @@
+package model
+
+import "api5back/src/processing"
+
+type MetricsData struct {
+	VacancySummary    processing.VacancyStatusSummary      `json:"vacancyStatus"`
+	CardInfos         processing.CardInfos                 `json:"cards"`
+	AverageHiringTime processing.AverageHiringTimePerMonth `json:"averageHiringTime"`
+}
+
+type TableData struct {
+	Title             string   `json:"title"`
+	NumPositions      int      `json:"numPositions"`
+	NumCandidates     int      `json:"numCandidates"`
+	CompetitionRate   *float32 `json:"competitionRate"`
+	NumInterviewed    int      `json:"numInterviewed"`
+	NumHired          int      `json:"numHired"`
+	AverageHiringTime *float32 `json:"averageHiringTime"`
+	NumFeedback       int      `json:"numFeedback"`
+}

--- a/src/model/suggestion.go
+++ b/src/model/suggestion.go
@@ -1,0 +1,6 @@
+package model
+
+type Suggestion struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+}

--- a/src/model/suggestion.go
+++ b/src/model/suggestion.go
@@ -1,6 +1,6 @@
 package model
 
 type Suggestion struct {
-	Id   int    `json:"id"`
-	Name string `json:"name"`
+	Id    int    `json:"id"`
+	Title string `json:"title"`
 }

--- a/src/server/hiring_process.go
+++ b/src/server/hiring_process.go
@@ -5,16 +5,12 @@ import (
 	"net/http"
 
 	"api5back/ent"
+	"api5back/src/model"
 	"api5back/src/processing"
 	"api5back/src/service"
 
 	"github.com/gin-gonic/gin"
 )
-
-type SuggestionsResponse struct {
-	Id   int    `json:"id"`
-	Name string `json:"name"`
-}
 
 type TableResponse struct {
 	Title             string   `json:"title"`
@@ -185,9 +181,9 @@ func VacancyList(
 			return
 		}
 
-		var response []SuggestionsResponse
+		var response []model.Suggestion
 		for _, vacancy := range vacancies {
-			response = append(response, SuggestionsResponse{
+			response = append(response, model.Suggestion{
 				Id:   vacancy.ID,
 				Name: vacancy.Title,
 			})

--- a/src/server/hiring_process.go
+++ b/src/server/hiring_process.go
@@ -20,6 +20,7 @@ func HiringProcessDashboard(
 		hiringProcess := v1.Group("/hiring-process")
 		{
 			hiringProcess.POST("/dashboard", Dashboard(dwClient))
+			hiringProcess.POST("/table", VacancyTable(dwClient))
 		}
 
 		suggestions := v1.Group("/suggestions")
@@ -27,11 +28,6 @@ func HiringProcessDashboard(
 			suggestions.GET("/recruiter", UserList(dwClient))
 			suggestions.POST("/process", HiringProcessList((dwClient)))
 			suggestions.POST("/vacancies", VacancyList(dwClient))
-		}
-
-		table := v1.Group("/table")
-		{
-			table.POST("/dashboard", VacancyTable(dwClient))
 		}
 	}
 }
@@ -191,7 +187,7 @@ func VacancyList(
 // @Param body body service.FactHiringProcessFilter true "Metrics filter"
 // @Produce json
 // @Success 200 {array} model.Suggestion
-// @Router /table/dashboard [post]
+// @Router /api/v1/hiring-process/table [post]
 func VacancyTable(
 	dwClient *ent.Client,
 ) func(c *gin.Context) {

--- a/src/server/hiring_process.go
+++ b/src/server/hiring_process.go
@@ -47,6 +47,7 @@ func Dashboard(
 	return func(c *gin.Context) {
 		c.Header("Content-Type", "application/json")
 
+		// TODO: change to pointer
 		var dashboardMetricsFilter service.FactHiringProcessFilter
 		if err := c.ShouldBindJSON(&dashboardMetricsFilter); err != nil {
 			c.JSON(http.StatusBadRequest, err.Error())
@@ -70,6 +71,7 @@ func TableData(
 	dwClient *ent.Client,
 ) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		c.Header("Content-Type", "application/json")
 		var userIDs []int
 
 		// Parse the body for user IDs
@@ -91,6 +93,7 @@ func TableData(
 // @Router /suggestions/recruiter/ [get]
 func UserList(dwClient *ent.Client) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		c.Header("Content-Type", "application/json")
 		users, err := service.GetUsers(c, dwClient)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, err.Error())
@@ -115,7 +118,8 @@ func HiringProcessList(
 	dbClient *ent.Client,
 ) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		var userIDs []int
+		c.Header("Content-Type", "application/json")
+		var userIDs *[]int
 
 		// Parse the body for user IDs
 		if err := c.ShouldBindJSON(&userIDs); err != nil {
@@ -142,7 +146,7 @@ func HiringProcessList(
 // @Description Return a list of hiring processes with id and title
 // @Tags suggestions
 // @Accept json
-// @Param body body []int true "User IDs"
+// @Param body body []int false "User IDs"
 // @Produce json
 // @Success 200 {array} model.Suggestion
 // @Router /suggestions/vacancies [post]
@@ -150,7 +154,8 @@ func VacancyList(
 	dwClient *ent.Client,
 ) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		var processesIds []int
+		c.Header("Content-Type", "application/json")
+		var processesIds *[]int
 		if err := c.ShouldBindJSON(&processesIds); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
 			return
@@ -183,6 +188,7 @@ func VacancyTable(
 	dwClient *ent.Client,
 ) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		c.Header("Content-Type", "application/json")
 		var filter service.FactHiringProcessFilter
 		if err := c.ShouldBindJSON(&filter); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})

--- a/src/server/hiring_process.go
+++ b/src/server/hiring_process.go
@@ -149,7 +149,7 @@ func HiringProcessList(
 // @Param body body []int false "User IDs"
 // @Produce json
 // @Success 200 {array} model.Suggestion
-// @Router /suggestions/vacancies [post]
+// @Router /suggestions/vacancy [post]
 func VacancyList(
 	dwClient *ent.Client,
 ) func(c *gin.Context) {
@@ -183,7 +183,7 @@ func VacancyList(
 // @Param body body service.FactHiringProcessFilter true "Metrics filter"
 // @Produce json
 // @Success 200 {array} model.Suggestion
-// @Router /api/v1/hiring-process/table [post]
+// @Router /hiring-process/table [post]
 func VacancyTable(
 	dwClient *ent.Client,
 ) func(c *gin.Context) {

--- a/src/server/hiring_process.go
+++ b/src/server/hiring_process.go
@@ -1,17 +1,13 @@
 package server
 
 import (
+	"net/http"
+
 	"api5back/ent"
 	"api5back/src/service"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
-
-type SuggestionsResponse struct {
-	Id   int    `json:"id"`
-	Name string `json:"name"`
-}
 
 func HiringProcessDashboard(
 	engine *gin.Engine,
@@ -78,7 +74,7 @@ func Dashboard(
 // @Tags users
 // @Accept json
 // @Produce json
-// @Success 200 {array} SuggestionsResponse
+// @Success 200 {array} model.Suggestion
 // @Router /users/ [get]
 func UserList(
 	dwClient *ent.Client,
@@ -90,15 +86,7 @@ func UserList(
 			return
 		}
 
-		var response []SuggestionsResponse
-		for _, user := range users {
-			response = append(response, SuggestionsResponse{
-				Id:   user.ID,
-				Name: user.Name,
-			})
-		}
-
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, users)
 	}
 }
 
@@ -109,7 +97,7 @@ func UserList(
 // @Tags hiring-process
 // @Accept json
 // @Produce json
-// @Success 200 {array} SuggestionsResponse
+// @Success 200 {array} model.Suggestion
 // @Router /hiring-process [post]
 func HiringProcessList(
 	dbClient *ent.Client,
@@ -132,14 +120,6 @@ func HiringProcessList(
 			return
 		}
 
-		var response []SuggestionsResponse
-		for _, process := range processes {
-			response = append(response, SuggestionsResponse{
-				Id:   process.ID,
-				Name: process.Title,
-			})
-		}
-
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, processes)
 	}
 }

--- a/src/server/hiring_process.go
+++ b/src/server/hiring_process.go
@@ -26,7 +26,7 @@ func HiringProcessDashboard(
 		{
 			suggestions.GET("/recruiter", UserList(dwClient))
 			suggestions.POST("/process", HiringProcessList((dwClient)))
-			suggestions.POST("/vacancies", VacancyList(dwClient))
+			suggestions.POST("/vacancy", VacancyList(dwClient))
 		}
 	}
 }

--- a/src/server/hiring_process.go
+++ b/src/server/hiring_process.go
@@ -1,27 +1,14 @@
 package server
 
 import (
-	"fmt"
 	"net/http"
 
 	"api5back/ent"
 	"api5back/src/model"
-	"api5back/src/processing"
 	"api5back/src/service"
 
 	"github.com/gin-gonic/gin"
 )
-
-type TableResponse struct {
-	Title             string   `json:"title"`
-	NumPositions      int      `json:"numPositions"`
-	NumCandidates     int      `json:"numCandidates"`
-	CompetitionRate   *float32 `json:"competitionRate"`
-	NumInterviewed    int      `json:"numInterviewed"`
-	NumHired          int      `json:"numHired"`
-	AverageHiringTime *float32 `json:"averageHiringTime"`
-	NumFeedback       int      `json:"numFeedback"`
-}
 
 func HiringProcessDashboard(
 	engine *gin.Engine,
@@ -221,41 +208,6 @@ func VacancyTable(
 			return
 		}
 
-		fmt.Println("Vagas retornadas:", vacancies)
-
-		var response []TableResponse
-		for _, vacancy := range vacancies {
-
-			numPositions := vacancy.Edges.DimVacancy.NumPositions
-			var competitionRate *float32
-			if numPositions > 0 {
-				rate := float32(vacancy.MetTotalCandidatesApplied) / float32(numPositions)
-				competitionRate = &rate
-			} else {
-				competitionRate = nil
-			}
-
-			hiringTime, err := processing.GenerateAverageHiringTimePerFactHiringProcess(vacancy)
-			var averageHiringTime *float32
-			if err != nil {
-				averageHiringTime = nil
-			} else {
-				averageHiringTime = &(hiringTime)
-			}
-
-			numFeedback := vacancy.MetTotalFeedbackPositive + vacancy.MetTotalNegative + vacancy.MetTotalNeutral
-			response = append(response, TableResponse{
-				Title:             vacancy.Edges.DimVacancy.Title,
-				NumPositions:      numPositions,
-				NumCandidates:     vacancy.MetTotalCandidatesApplied,
-				CompetitionRate:   competitionRate,
-				NumInterviewed:    vacancy.MetTotalCandidatesInterviewed,
-				NumHired:          vacancy.MetTotalCandidatesHired,
-				AverageHiringTime: averageHiringTime,
-				NumFeedback:       numFeedback,
-			})
-		}
-
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, vacancies)
 	}
 }

--- a/src/server/hiring_process.go
+++ b/src/server/hiring_process.go
@@ -40,9 +40,9 @@ func HiringProcessDashboard(
 // @Summary dashboard
 // @Schemes
 // @Description show dashboard
-// @Tags dashboard
+// @Tags hiring-process
 // @Accept json
-// @Param body body service.DashboardMetricsFilter true "Metrics filter"
+// @Param body body service.FactHiringProcessFilter true "Metrics filter"
 // @Produce json
 // @Success 200 {string} Dashboard
 // @Router /hiring-process/dashboard [post]
@@ -89,11 +89,11 @@ func TableData(
 // @Summary List users
 // @Schemes
 // @Description Return a list of users with id and name
-// @Tags users
+// @Tags suggestions
 // @Accept json
 // @Produce json
 // @Success 200 {array} model.Suggestion
-// @Router /users/ [get]
+// @Router /suggestions/recruiter/ [get]
 func UserList(dwClient *ent.Client) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		users, err := service.GetUsers(c, dwClient)
@@ -110,11 +110,12 @@ func UserList(dwClient *ent.Client) func(c *gin.Context) {
 // @Summary List hiring processes
 // @Schemes
 // @Description Return a list of hiring processes with id and title
-// @Tags hiring-process
+// @Tags suggestions
 // @Accept json
+// @Param body body []int true "User IDs"
 // @Produce json
 // @Success 200 {array} model.Suggestion
-// @Router /hiring-process [post]
+// @Router /suggestions/process [post]
 func HiringProcessList(
 	dbClient *ent.Client,
 ) func(c *gin.Context) {
@@ -144,10 +145,11 @@ func HiringProcessList(
 // @Summary List hiring processes
 // @Schemes
 // @Description Return a list of hiring processes with id and title
-// @Tags hiring-process
+// @Tags suggestions
 // @Accept json
+// @Param body body []int true "User IDs"
 // @Produce json
-// @Success 200 {array} SuggestionsResponse
+// @Success 200 {array} model.Suggestion
 // @Router /suggestions/vacancies [post]
 func VacancyList(
 	dwClient *ent.Client,
@@ -183,12 +185,13 @@ func VacancyList(
 // HiringProcessList godoc
 // @Summary List hiring processes
 // @Schemes
-// @Description Return a list of hiring processes with id and title
+// @Description Return a list of vacancies with summarized information
 // @Tags hiring-process
 // @Accept json
+// @Param body body service.FactHiringProcessFilter true "Metrics filter"
 // @Produce json
-// @Success 200 {array} SuggestionsResponse
-// @Router /suggestions/vacancies [post]
+// @Success 200 {array} model.Suggestion
+// @Router /table/dashboard [post]
 func VacancyTable(
 	dwClient *ent.Client,
 ) func(c *gin.Context) {

--- a/src/server/hiring_process.go
+++ b/src/server/hiring_process.go
@@ -82,7 +82,7 @@ func UserList(
 	return func(c *gin.Context) {
 		users, err := service.GetUsers(c, dwClient)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusInternalServerError, err.Error())
 			return
 		}
 
@@ -107,7 +107,7 @@ func HiringProcessList(
 
 		// Parse the body for user IDs
 		if err := c.ShouldBindJSON(&userIDs); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+			c.JSON(http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -116,7 +116,7 @@ func HiringProcessList(
 			userIDs,
 		)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusInternalServerError, err.Error())
 			return
 		}
 

--- a/src/server/hiring_process.go
+++ b/src/server/hiring_process.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"api5back/ent"
-	"api5back/src/model"
 	"api5back/src/service"
 
 	"github.com/gin-gonic/gin"
@@ -166,15 +165,7 @@ func VacancyList(
 			return
 		}
 
-		var response []model.Suggestion
-		for _, vacancy := range vacancies {
-			response = append(response, model.Suggestion{
-				Id:   vacancy.ID,
-				Name: vacancy.Title,
-			})
-		}
-
-		c.JSON(http.StatusOK, response)
+		c.JSON(http.StatusOK, vacancies)
 	}
 }
 

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -1,8 +1,9 @@
 package server
 
 import (
-	"api5back/ent"
 	"net/http"
+
+	"api5back/ent"
 
 	"github.com/gin-gonic/gin"
 )

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -14,10 +14,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-type MetricsService struct {
-	dbClient *ent.Client
-}
-
 type MetricsData struct {
 	VacancySummary    processing.VacancyStatusSummary      `json:"vacancyStatus"`
 	CardInfos         processing.CardInfos                 `json:"cards"`
@@ -30,16 +26,14 @@ type GetMetricsFilter struct {
 	StartDate         string `json:"startDate"`
 	EndDate           string `json:"endDate"`
 }
-
-func NewMetricsService(dbclient *ent.Client) *MetricsService {
-	return &MetricsService{dbClient: dbclient}
 }
 
-func (s *MetricsService) GetMetrics(
+func GetMetrics(
 	ctx context.Context,
-	filter GetMetricsFilter,
+	client *ent.Client,
+	filter DashboardMetricsFilter,
 ) (*MetricsData, error) {
-	query := s.dbClient.
+	query := client.
 		FactHiringProcess.
 		Query().
 		WithDimVacancy().

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -9,6 +9,7 @@ import (
 	"api5back/ent/dimprocess"
 	"api5back/ent/dimvacancy"
 	"api5back/ent/facthiringprocess"
+	"api5back/src/model"
 	"api5back/src/processing"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -28,28 +29,11 @@ type FactHiringProcessFilter struct {
 	VacancyStatus []int      `json:"vacancyStatus"`
 }
 
-type MetricsData struct {
-	VacancySummary    processing.VacancyStatusSummary      `json:"vacancyStatus"`
-	CardInfos         processing.CardInfos                 `json:"cards"`
-	AverageHiringTime processing.AverageHiringTimePerMonth `json:"averageHiringTime"`
-}
-
-type TableData struct {
-	Title             string   `json:"title"`
-	NumPositions      int      `json:"numPositions"`
-	NumCandidates     int      `json:"numCandidates"`
-	CompetitionRate   *float32 `json:"competitionRate"`
-	NumInterviewed    int      `json:"numInterviewed"`
-	NumHired          int      `json:"numHired"`
-	AverageHiringTime *float32 `json:"averageHiringTime"`
-	NumFeedback       int      `json:"numFeedback"`
-}
-
 func GetMetrics(
 	ctx context.Context,
 	client *ent.Client,
 	filter FactHiringProcessFilter,
-) (*MetricsData, error) {
+) (*model.MetricsData, error) {
 	query := client.
 		FactHiringProcess.
 		Query().
@@ -158,7 +142,7 @@ func GetMetrics(
 		)
 	}
 
-	return &MetricsData{
+	return &model.MetricsData{
 		CardInfos:         cardInfo,
 		VacancySummary:    vacancyInfo,
 		AverageHiringTime: averageHiringTime,
@@ -192,7 +176,7 @@ func GetVacancyTable(
 	ctx context.Context,
 	client *ent.Client,
 	filter FactHiringProcessFilter,
-) ([]TableData, error) {
+) ([]model.TableData, error) {
 	query := client.FactHiringProcess.Query().WithDimProcess().WithDimVacancy()
 
 	if len(filter.Recruiters) > 0 {
@@ -284,7 +268,7 @@ func GetVacancyTable(
 		return nil, err
 	}
 
-	var tableDatas []TableData
+	var tableDatas []model.TableData
 	for _, vacancy := range vacancies {
 
 		numPositions := vacancy.Edges.DimVacancy.NumPositions
@@ -305,7 +289,7 @@ func GetVacancyTable(
 		}
 
 		numFeedback := vacancy.MetTotalFeedbackPositive + vacancy.MetTotalNegative + vacancy.MetTotalNeutral
-		tableDatas = append(tableDatas, TableData{
+		tableDatas = append(tableDatas, model.TableData{
 			Title:             vacancy.Edges.DimVacancy.Title,
 			NumPositions:      numPositions,
 			NumCandidates:     vacancy.MetTotalCandidatesApplied,

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -7,6 +7,7 @@ import (
 
 	"api5back/ent"
 	"api5back/ent/dimprocess"
+	"api5back/ent/dimuser"
 	"api5back/ent/dimvacancy"
 	"api5back/ent/facthiringprocess"
 	"api5back/src/model"
@@ -53,6 +54,14 @@ func GetMetrics(
 		query = query.Where(
 			facthiringprocess.HasDimVacancyWith(
 				dimvacancy.IDIn(filter.Vacancies...),
+			),
+		)
+	}
+
+	if len(filter.Recruiters) > 0 {
+		query = query.Where(
+			facthiringprocess.HasDimUserWith(
+				dimuser.IDIn(filter.Recruiters...),
 			),
 		)
 	}

--- a/src/service/service_integration_test.go
+++ b/src/service/service_integration_test.go
@@ -118,7 +118,7 @@ func TestDatabaseOperations(t *testing.T) {
 		metricsService := NewMetricsService(intEnv.Client)
 		metricsData, err := metricsService.GetMetrics(
 			ctx,
-			GetMetricsFilter{
+			DashboardMetricsFilter{
 				HiringProcessName: "",
 				VacancyName:       "",
 				StartDate:         "",

--- a/src/service/service_process.go
+++ b/src/service/service_process.go
@@ -5,6 +5,7 @@ import (
 
 	"api5back/ent"
 	"api5back/ent/dimprocess"
+	"api5back/src/model"
 )
 
 func ListHiringProcesses(
@@ -22,5 +23,14 @@ func ListHiringProcesses(
 	if err != nil {
 		return nil, err
 	}
+
+	var response []model.Suggestion
+	for _, process := range processes {
+		response = append(response, model.Suggestion{
+			Id:   process.ID,
+			Name: process.Title,
+		})
+	}
+
 	return processes, nil
 }

--- a/src/service/service_process.go
+++ b/src/service/service_process.go
@@ -12,7 +12,7 @@ func ListHiringProcesses(
 	ctx context.Context,
 	client *ent.Client,
 	userIDs []int,
-) ([]*ent.DimProcess, error) {
+) ([]model.Suggestion, error) {
 	query := client.DimProcess.Query()
 
 	if len(userIDs) > 0 {
@@ -32,5 +32,5 @@ func ListHiringProcesses(
 		})
 	}
 
-	return processes, nil
+	return response, nil
 }

--- a/src/service/service_process.go
+++ b/src/service/service_process.go
@@ -27,8 +27,8 @@ func ListHiringProcesses(
 	var response []model.Suggestion
 	for _, process := range processes {
 		response = append(response, model.Suggestion{
-			Id:   process.ID,
-			Name: process.Title,
+			Id:    process.ID,
+			Title: process.Title,
 		})
 	}
 

--- a/src/service/service_process.go
+++ b/src/service/service_process.go
@@ -11,12 +11,12 @@ import (
 func ListHiringProcesses(
 	ctx context.Context,
 	client *ent.Client,
-	userIDs []int,
+	userIDs *[]int,
 ) ([]model.Suggestion, error) {
 	query := client.DimProcess.Query()
 
-	if len(userIDs) > 0 {
-		query = query.Where(dimprocess.DimUsrIdIn(userIDs...))
+	if userIDs != nil {
+		query = query.Where(dimprocess.DimUsrIdIn(*userIDs...))
 	}
 
 	processes, err := query.All(ctx)

--- a/src/service/service_process.go
+++ b/src/service/service_process.go
@@ -15,7 +15,8 @@ func ListHiringProcesses(
 ) ([]model.Suggestion, error) {
 	query := client.DimProcess.Query()
 
-	if userIDs != nil {
+	// Verificar se o array de userIDs não é nil e se tem elementos
+	if userIDs != nil && len(*userIDs) > 0 {
 		query = query.Where(dimprocess.DimUsrIdIn(*userIDs...))
 	}
 

--- a/src/service/service_process.go
+++ b/src/service/service_process.go
@@ -1,21 +1,18 @@
 package service
 
 import (
+	"context"
+
 	"api5back/ent"
 	"api5back/ent/dimprocess"
-	"context"
 )
 
-type HiringProcessService struct {
-	client *ent.Client
-}
-
-func NewHiringProcessService(client *ent.Client) *HiringProcessService {
-	return &HiringProcessService{client: client}
-}
-
-func (s *HiringProcessService) ListHiringProcesses(ctx context.Context, userIDs []int) ([]*ent.DimProcess, error) {
-	query := s.client.DimProcess.Query()
+func ListHiringProcesses(
+	ctx context.Context,
+	client *ent.Client,
+	userIDs []int,
+) ([]*ent.DimProcess, error) {
+	query := client.DimProcess.Query()
 
 	if len(userIDs) > 0 {
 		query = query.Where(dimprocess.DimUsrIdIn(userIDs...))

--- a/src/service/service_user.go
+++ b/src/service/service_user.go
@@ -11,7 +11,7 @@ import (
 func GetUsers(
 	ctx context.Context,
 	client *ent.Client,
-) ([]*ent.DimUser, error) {
+) ([]model.Suggestion, error) {
 	users, err := client.DimUser.
 		Query().
 		Select(dimuser.FieldID, dimuser.FieldName).
@@ -28,5 +28,5 @@ func GetUsers(
 		})
 	}
 
-	return users, nil
+	return response, nil
 }

--- a/src/service/service_user.go
+++ b/src/service/service_user.go
@@ -5,6 +5,7 @@ import (
 
 	"api5back/ent"
 	"api5back/ent/dimuser"
+	"api5back/src/model"
 )
 
 func GetUsers(
@@ -18,5 +19,14 @@ func GetUsers(
 	if err != nil {
 		return nil, err
 	}
+
+	var response []model.Suggestion
+	for _, user := range users {
+		response = append(response, model.Suggestion{
+			Id:   user.ID,
+			Name: user.Name,
+		})
+	}
+
 	return users, nil
 }

--- a/src/service/service_user.go
+++ b/src/service/service_user.go
@@ -23,8 +23,8 @@ func GetUsers(
 	var response []model.Suggestion
 	for _, user := range users {
 		response = append(response, model.Suggestion{
-			Id:   user.ID,
-			Name: user.Name,
+			Id:    user.ID,
+			Title: user.Name,
 		})
 	}
 

--- a/src/service/service_user.go
+++ b/src/service/service_user.go
@@ -1,21 +1,17 @@
 package service
 
 import (
+	"context"
+
 	"api5back/ent"
 	"api5back/ent/dimuser"
-	"context"
 )
 
-type UserService struct {
-	dwClient *ent.Client
-}
-
-func NewUserService(dwClient *ent.Client) *UserService {
-	return &UserService{dwClient: dwClient}
-}
-
-func (s *UserService) GetUsers(ctx context.Context) ([]*ent.DimUser, error) {
-	users, err := s.dwClient.DimUser.
+func GetUsers(
+	ctx context.Context,
+	client *ent.Client,
+) ([]*ent.DimUser, error) {
+	users, err := client.DimUser.
 		Query().
 		Select(dimuser.FieldID, dimuser.FieldName).
 		All(ctx)

--- a/src/service/service_vacancy.go
+++ b/src/service/service_vacancy.go
@@ -13,12 +13,11 @@ func GetVacancySuggestions(
 	client *ent.Client,
 	processesIds *[]int,
 ) ([]model.Suggestion, error) {
-	query := client.FactHiringProcess.Query()
+	query := client.FactHiringProcess.Query().WithDimVacancy() // Com WithDimVacancy sempre incluído
 
-	if processesIds != nil {
+	// Se processesIds não for nil e não estiver vazio, aplicamos o filtro
+	if processesIds != nil && len(*processesIds) > 0 {
 		query = query.Where(facthiringprocess.DimProcessIdIn(*processesIds...))
-		query = query.WithDimVacancy()
-
 	}
 
 	vacancies, err := query.All(ctx)
@@ -38,7 +37,7 @@ func GetVacancySuggestions(
 		}
 	}
 
-	// Convert the map to a slice
+	// Convertendo o map para slice
 	result := make([]model.Suggestion, 0, len(uniqueVacancies))
 	for _, v := range uniqueVacancies {
 		result = append(result, v)

--- a/src/service/service_vacancy.go
+++ b/src/service/service_vacancy.go
@@ -5,18 +5,14 @@ import (
 
 	"api5back/ent"
 	"api5back/ent/facthiringprocess"
+	"api5back/src/model"
 )
-
-type UniqueVacancy struct {
-	ID    int
-	Title string
-}
 
 func GetVacancySuggestions(
 	ctx context.Context,
 	client *ent.Client,
 	processesIds []int,
-) ([]UniqueVacancy, error) {
+) ([]model.Suggestion, error) {
 	query := client.FactHiringProcess.Query()
 
 	if len(processesIds) > 0 {
@@ -30,20 +26,20 @@ func GetVacancySuggestions(
 		return nil, err
 	}
 
-	uniqueVacancies := make(map[int]UniqueVacancy)
+	uniqueVacancies := make(map[int]model.Suggestion)
 
 	for _, fact := range vacancies {
 		if fact.Edges.DimVacancy != nil {
 			vacancy := fact.Edges.DimVacancy
-			uniqueVacancies[vacancy.ID] = UniqueVacancy{
-				ID:    vacancy.ID,
-				Title: vacancy.Title,
+			uniqueVacancies[vacancy.ID] = model.Suggestion{
+				Id:   vacancy.ID,
+				Name: vacancy.Title,
 			}
 		}
 	}
 
 	// Convert the map to a slice
-	result := make([]UniqueVacancy, 0, len(uniqueVacancies))
+	result := make([]model.Suggestion, 0, len(uniqueVacancies))
 	for _, v := range uniqueVacancies {
 		result = append(result, v)
 	}

--- a/src/service/service_vacancy.go
+++ b/src/service/service_vacancy.go
@@ -32,8 +32,8 @@ func GetVacancySuggestions(
 		if fact.Edges.DimVacancy != nil {
 			vacancy := fact.Edges.DimVacancy
 			uniqueVacancies[vacancy.ID] = model.Suggestion{
-				Id:   vacancy.ID,
-				Name: vacancy.Title,
+				Id:    vacancy.ID,
+				Title: vacancy.Title,
 			}
 		}
 	}

--- a/src/service/service_vacancy.go
+++ b/src/service/service_vacancy.go
@@ -11,12 +11,12 @@ import (
 func GetVacancySuggestions(
 	ctx context.Context,
 	client *ent.Client,
-	processesIds []int,
+	processesIds *[]int,
 ) ([]model.Suggestion, error) {
 	query := client.FactHiringProcess.Query()
 
-	if len(processesIds) > 0 {
-		query = query.Where(facthiringprocess.DimProcessIdIn(processesIds...))
+	if processesIds != nil {
+		query = query.Where(facthiringprocess.DimProcessIdIn(*processesIds...))
 		query = query.WithDimVacancy()
 
 	}


### PR DESCRIPTION
+ permite rodar as seeds sem confirmação (y/N) 
+ resolve #44
+ alterações opinadas diversas
+ fixes diversos

## pontos de teste:
- Script de seeds executa sem confirmação ao passar a flag `-y`; Ex.:
  - `go run scripts/seeds/main.go dw -y`
  - `make seeds-y dw`
  - `make sy dw`
- Swagger exibe corretamente a as urls dos endpoints e requisições são recebidas pela api;
- Endpoints `/suggestions` funcionam com `[]` (lista vazia) como body da requisição