### PR TITLE
fix: revert `TableData` fields lost during conflict resolution

### DIFF
--- a/src/model/factHiringProcess.go
+++ b/src/model/factHiringProcess.go
@@ -9,7 +9,8 @@ type MetricsData struct {
 }
 
 type TableData struct {
-	Title             string   `json:"title"`
+	ProcessTitle      string   `json:"processTitle"`
+	VacancyTitle      string   `json:"vacancyTitle"`
 	NumPositions      int      `json:"numPositions"`
 	NumCandidates     int      `json:"numCandidates"`
 	CompetitionRate   *float32 `json:"competitionRate"`

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -181,14 +181,6 @@ func ParseStringToPgtypeDate(
 	}, nil
 }
 
-type VacancyServiceTable struct {
-	dwClient *ent.Client
-}
-
-func NewVacancyServiceTable(client *ent.Client) *VacancyServiceTable {
-	return &VacancyServiceTable{dwClient: client}
-}
-
 func GetVacancyTable(
 	ctx context.Context,
 	client *ent.Client,
@@ -305,7 +297,6 @@ func GetVacancyTable(
 	query = query.Offset(offset).Limit(*filter.PageSize)
 
 	vacancies, err := query.All(ctx)
-
 	if err != nil {
 		return nil, err
 	}

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -332,7 +332,8 @@ func GetVacancyTable(
 
 		numFeedback := vacancy.MetTotalFeedbackPositive + vacancy.MetTotalNegative + vacancy.MetTotalNeutral
 		tableDatas = append(tableDatas, model.TableData{
-			Title:             vacancy.Edges.DimVacancy.Title,
+			ProcessTitle:      vacancy.Edges.DimProcess.Title,
+			VacancyTitle:      vacancy.Edges.DimVacancy.Title,
 			NumPositions:      numPositions,
 			NumCandidates:     vacancy.MetTotalCandidatesApplied,
 			CompetitionRate:   competitionRate,


### PR DESCRIPTION
- Campos `ProcessTitle` e `VacancyTitle` reintroduzidos após serem removidos erroneamente durante resolução de conflitos de merge do branch `report-pagination` com `dev`
- Struct `VacancyServiceTable` e construtor `NewVacancyServiceTable` removidos pois service não segue mais padrão que exige instância; 